### PR TITLE
modifica para ser unique o username

### DIFF
--- a/src/main/java/com/project/mylinks/api/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/mylinks/api/advice/GlobalExceptionHandler.java
@@ -1,10 +1,7 @@
 package com.project.mylinks.api.advice;
 
 
-import com.project.mylinks.application.exception.BusinessValidationException;
-import com.project.mylinks.application.exception.EmailAlreadyUseException;
-import com.project.mylinks.application.exception.LinksNotFoundException;
-import com.project.mylinks.application.exception.UserNotFoundException;
+import com.project.mylinks.application.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,9 +18,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Object> handleUserNotFound(UserNotFoundException ex) {
         return buildErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND);
     }
+    @ExceptionHandler(UsernameAlreadyUseException.class)
+    public ResponseEntity<Object> handleUsernameAlreadyUseException(UsernameAlreadyUseException ex){
+        return buildErrorResponse(ex.getMessage(), HttpStatus.CONFLICT);
+    }
     @ExceptionHandler(EmailAlreadyUseException.class)
     public ResponseEntity<Object> handleEmailAlreadyUsed(EmailAlreadyUseException ex) {
-        return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
+        return buildErrorResponse(ex.getMessage(), HttpStatus.CONFLICT);
     }
     @ExceptionHandler
     public ResponseEntity<Object> handlerLinksNotFound(LinksNotFoundException ex){

--- a/src/main/java/com/project/mylinks/application/exception/UsernameAlreadyUseException.java
+++ b/src/main/java/com/project/mylinks/application/exception/UsernameAlreadyUseException.java
@@ -1,0 +1,7 @@
+package com.project.mylinks.application.exception;
+
+public class UsernameAlreadyUseException extends RuntimeException {
+    public UsernameAlreadyUseException() {
+        super("Username já em uso!");
+    }
+}

--- a/src/main/java/com/project/mylinks/application/exception/UsernameAlreadyUseException.java
+++ b/src/main/java/com/project/mylinks/application/exception/UsernameAlreadyUseException.java
@@ -2,6 +2,6 @@ package com.project.mylinks.application.exception;
 
 public class UsernameAlreadyUseException extends RuntimeException {
     public UsernameAlreadyUseException() {
-        super("Username já em uso!");
+        super("Username já em uso");
     }
 }

--- a/src/main/java/com/project/mylinks/application/service/AuthService.java
+++ b/src/main/java/com/project/mylinks/application/service/AuthService.java
@@ -8,6 +8,7 @@ import com.project.mylinks.application.domain.service.PasswordService;
 import com.project.mylinks.application.domain.service.TokenService;
 import com.project.mylinks.application.exception.EmailAlreadyUseException;
 import com.project.mylinks.application.exception.UserNotFoundException;
+import com.project.mylinks.application.exception.UsernameAlreadyUseException;
 import com.project.mylinks.domain.model.User;
 import com.project.mylinks.infrastructure.persistency.jpa.UserRepositoryJpa;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -55,6 +56,8 @@ public class AuthService {
     public void signUp(CreateUserDTO dto) {
         if (repository.existsByEmail(dto.email()))
             throw new EmailAlreadyUseException();
+        if (repository.existsByUsername(dto.username()))
+            throw new UsernameAlreadyUseException();
 
         User user = toEntity(dto);
         user.setPassword(passwordService.encode(user.getPassword()));

--- a/src/main/java/com/project/mylinks/domain/model/User.java
+++ b/src/main/java/com/project/mylinks/domain/model/User.java
@@ -23,7 +23,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "user_id")
     private UUID id;
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String username;
     private String password;
     private String email;

--- a/src/main/java/com/project/mylinks/domain/model/User.java
+++ b/src/main/java/com/project/mylinks/domain/model/User.java
@@ -23,6 +23,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "user_id")
     private UUID id;
+    @Column(unique = true)
     private String username;
     private String password;
     private String email;

--- a/src/main/java/com/project/mylinks/infrastructure/persistency/jpa/UserRepositoryJpa.java
+++ b/src/main/java/com/project/mylinks/infrastructure/persistency/jpa/UserRepositoryJpa.java
@@ -14,7 +14,7 @@ public interface UserRepositoryJpa extends JpaRepository<User, UUID> {
 
     boolean existsByEmail(String email);
 
-
+    boolean existsByUsername(String username);
     Optional<User> findByRefreshToken(String refreshToken);
 
 

--- a/src/test/java/com/project/mylinks/integration/auth/controller/AuthControllerTests.java
+++ b/src/test/java/com/project/mylinks/integration/auth/controller/AuthControllerTests.java
@@ -93,7 +93,7 @@ class AuthControllerTests {
         mockMvc.perform(post("/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(asJson(dto)))
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.mensagem")
                         .value("Email já em uso"));
     }
@@ -109,6 +109,18 @@ class AuthControllerTests {
                 .andExpect(status().isBadRequest());
     }
 
+
+    @Test
+    void shouldNotSignupWithDuplicateUsername() throws Exception {
+        CreateUserDTO dto = new CreateUserDTO("test", "new@gmail.com", "123");
+
+        mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJson(dto)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.mensagem")
+                        .value("Username já em uso"));
+    }
 
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced unique, non-null usernames to prevent duplicate accounts.
  * Signup now rejects duplicate usernames and emails with HTTP 409 Conflict, providing a clear "Username já em uso" message for username collisions.

* **Tests**
  * Added/updated integration tests to assert 409 Conflict responses for duplicate username and email signups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->